### PR TITLE
Restructure CPU parsing helpers

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,7 +1,10 @@
+mod parser;
+
 use crate::corestat::{CoreStat, color_corestat};
 use crate::cpustat::{CPUStat, color_cpustat};
 use crate::usagestat::UsageStat;
 use crate::utils::{color, color_based_on_percentage, color_head};
+use parser::{get_total_from_stat, merge_totals, parse_stat_line};
 use std::f64;
 
 fn get_cpu_or_core_stats(target: &str) -> Option<UsageStat> {
@@ -10,49 +13,14 @@ fn get_cpu_or_core_stats(target: &str) -> Option<UsageStat> {
         l.starts_with(target)
             && l[target.len()..].starts_with(|c: char| c == ' ' || !c.is_ascii_digit())
     })?;
-    let mut nums = line
-        .split_whitespace()
-        .skip(1)
-        .map(|n| n.parse::<u64>().unwrap_or(0));
-    let stats = UsageStat {
-        user: nums.next().unwrap_or(0),
-        nice: nums.next().unwrap_or(0),
-        system: nums.next().unwrap_or(0),
-        idle: nums.next().unwrap_or(0),
-        iowait: nums.next().unwrap_or(0),
-        irq: nums.next().unwrap_or(0),
-        softirq: nums.next().unwrap_or(0),
-        steal: nums.next().unwrap_or(0),
-        guest: nums.next().unwrap_or(0),
-        guest_nice: nums.next().unwrap_or(0),
-    };
-    Some(stats)
+    Some(parse_stat_line(line))
 }
 
 fn get_total(target: &str) -> (u64, u64) {
-    let stats = match get_cpu_or_core_stats(target) {
-        Some(s) => s,
-        None => return (0, 0),
-    };
-    let total = stats.user
-        + stats.nice
-        + stats.system
-        + stats.idle
-        + stats.iowait
-        + stats.irq
-        + stats.softirq
-        + stats.guest
-        + stats.guest_nice
-        + stats.steal;
-    let idle_total = stats.idle + stats.iowait;
-    (total, idle_total)
-}
-
-fn merge_totals((total1, idle_total1): (u64, u64), (total2, idle_total2): (u64, u64)) -> f64 {
-    let total = total2 - total1;
-    let idle_total = idle_total2 - idle_total1;
-
-    100.0 * (1.0 - idle_total as f64 / total as f64)
+    match get_cpu_or_core_stats(target) {
+        Some(s) => get_total_from_stat(s),
+        None => (0, 0),
+    }
 }
 
 fn calc_usage(target: &str) -> f64 {

--- a/src/cpu/parser.rs
+++ b/src/cpu/parser.rs
@@ -1,0 +1,74 @@
+use crate::usagestat::UsageStat;
+
+pub fn parse_stat_line(line: &str) -> UsageStat {
+    let mut nums = line
+        .split_whitespace()
+        .skip(1)
+        .map(|n| n.parse::<u64>().unwrap_or(0));
+    UsageStat {
+        user: nums.next().unwrap_or(0),
+        nice: nums.next().unwrap_or(0),
+        system: nums.next().unwrap_or(0),
+        idle: nums.next().unwrap_or(0),
+        iowait: nums.next().unwrap_or(0),
+        irq: nums.next().unwrap_or(0),
+        softirq: nums.next().unwrap_or(0),
+        steal: nums.next().unwrap_or(0),
+        guest: nums.next().unwrap_or(0),
+        guest_nice: nums.next().unwrap_or(0),
+    }
+}
+
+pub fn get_total_from_stat(stats: UsageStat) -> (u64, u64) {
+    let total = stats.user
+        + stats.nice
+        + stats.system
+        + stats.idle
+        + stats.iowait
+        + stats.irq
+        + stats.softirq
+        + stats.guest
+        + stats.guest_nice
+        + stats.steal;
+    let idle_total = stats.idle + stats.iowait;
+    (total, idle_total)
+}
+
+pub fn merge_totals((total1, idle_total1): (u64, u64), (total2, idle_total2): (u64, u64)) -> f64 {
+    let total = total2 - total1;
+    let idle_total = idle_total2 - idle_total1;
+
+    100.0 * (1.0 - idle_total as f64 / total as f64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_stat_line() {
+        let stat = parse_stat_line("cpu  1 2 3 4 5 6 7 8 9 10");
+        assert_eq!(stat.user, 1);
+        assert_eq!(stat.nice, 2);
+        assert_eq!(stat.system, 3);
+        assert_eq!(stat.idle, 4);
+        assert_eq!(stat.iowait, 5);
+        assert_eq!(stat.irq, 6);
+        assert_eq!(stat.softirq, 7);
+        assert_eq!(stat.steal, 8);
+        assert_eq!(stat.guest, 9);
+        assert_eq!(stat.guest_nice, 10);
+    }
+
+    #[test]
+    fn calculates_totals_from_stat() {
+        let stat = parse_stat_line("cpu0  10 20 30 40 50 60 70 80 90 100");
+        assert_eq!(get_total_from_stat(stat), (550, 90));
+    }
+
+    #[test]
+    fn merges_totals_into_usage_percentage() {
+        let usage = merge_totals((100, 40), (200, 60));
+        assert_eq!(usage, 80.0);
+    }
+}


### PR DESCRIPTION
This moves the pure CPU stat parsing and total calculation helpers into a dedicated parser module while keeping the existing public CPU printing functions and CLI behavior unchanged. The parser code no longer reads from /proc/stat directly, and the added unit tests cover stat-line parsing, total calculation, and usage percentage merging.